### PR TITLE
Fix compiler warning

### DIFF
--- a/mydecquad.c
+++ b/mydecquad.c
@@ -495,7 +495,7 @@ Ret_BCD mdq_to_BCD(decQuad a) {
 
   // convert to BCD
 
-  decQuadToBCD(&a, &exp, ret.BCD);  // this function returns a sign bit, but we don't use it because we don't want -0
+  decQuadToBCD(&a, &exp, (uint8_t*)ret.BCD);  // this function returns a sign bit, but we don't use it because we don't want -0
 
   sign = decQuadIsNegative(&a);     // 0 is never negative
 


### PR DESCRIPTION
```
$ go build
# github.com/rin01/decnum
./mydecquad.c:498:26: warning: passing 'char [34]' to parameter of type 'uint8_t *' (aka 'unsigned char *') converts between pointers to integer types with different sign [-Wpointer-sign]
./decQuad.h:94:70: note: passing argument to parameter here
```
